### PR TITLE
Fix possible invalid parsing config file

### DIFF
--- a/lib/fluent/plugin/out_mssql.rb
+++ b/lib/fluent/plugin/out_mssql.rb
@@ -39,7 +39,7 @@ class MssqlOutput < Fluent::BufferedOutput
     if @sql.nil?
       raise Fluent::ConfigError, "table missing" unless @table
 
-      @columns = @columns.split(',')
+      @columns = @columns.split(',').map(&:strip)
       cols = @columns.join(',')
       placeholders = if @format == 'json'
                        '?'


### PR DESCRIPTION
The "key_names" entry in config file is put in an array
separated by commas.
When there are some blanks around the comma, they are
not removed and space is included in array elements.
ex. "key_names aaa, bbb, ccc"=>["aaa", " bbb", " ccc"]
A correct array is: ["aaa", "bbb", "ccc"]
So fix it.

大変有用なプラグインを公開いただきありがとうございます。
自分で試したとき、configファイルに

> key_names    column1, column2, column3

と記述したところ、column1のみ値が入ってcolumn2とcolumn3はnilだった
ので、自分なりに調べて小さな修正を入れました。
宜しくお願いします。